### PR TITLE
Update alpine to version alpine3.13

### DIFF
--- a/cmak2zk/Dockerfile
+++ b/cmak2zk/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-alpine3.12
+FROM python:3.8-alpine3.13
 
 COPY *.py /app/bin/
 


### PR DESCRIPTION
The Installed operating system Alpine 3.12.7 has reached end of support since 01 May 2022 and does not get security patches. This leaves the system vulnerable to many security issues that can be exploited.

 For more information please visit https://alpinelinux.org/releases/

Test Green:

```shell
docker build -t cmak2zk .
docker run -it --rm cmak "ZK_URL=myzk1:2181,myzk2:2181" "--no-overwrite-zk" "YAML_CFG=/conf/value.yaml"
```
